### PR TITLE
fix: remove browser entry to prevent webpack from using UMD bundle by…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.1.5",
   "main": "dist/redux-rest-actions.cjs.js",
   "module": "dist/redux-rest-actions.esm.js",
-  "browser": "dist/redux-rest-actions.umd.js",
+  "type": "module",
+  "sideEffects": false,
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default [
     input: 'src/main.js',
     output: {
       name: 'main',
-      file: pkg.browser,
+      file: 'dist/redux-rest-actions.umd.js',
       format: 'umd'
     },
     plugins: [


### PR DESCRIPTION
Removing the browser entry in package.json so Webpack doesn't default to using the UMD bundle (which isn't tree shakeable) instead of the ESM bundle.